### PR TITLE
Update train_gmvsae.py

### DIFF
--- a/train_gmvsae.py
+++ b/train_gmvsae.py
@@ -188,7 +188,7 @@ class train_gmvsae:
         return torch.cat(G, 1)
 
     def Loss(self, x_hat, targets, z_mu, z_sigma2_log, z, lengths):
-        pi = self.model.pi_prior
+        pi = F.softmax(self.model.pi_prior, dim=-1)
         log_sigma2_c = self.model.log_var_prior
         mu_c = self.model.mu_prior
 


### PR DESCRIPTION
make sure sum(pi) == 1

训练时发现，其中的类别损失category_loss（类别损失, 当前分布q与先验分布pi之间的KL散度）有时为负数，不合理。（甚至会导致整体loss变负数）
修复前PR_AUC: 0.8102083517806609
经过调试，发现问题：原代码在计算KL散度时，对先验分布pi没有做softmax，pi的和大于1。
修复：在pi外面添加了一层softmax，保证pi的和为1，是有效的概率分布。
修复后的代码：
pi = F.softmax(self.model.pi_prior, dim=-1) # 确保 sum(pi) = 1
修复后PR_AUC: 0.8136903820684506，修复后效果有提升。

